### PR TITLE
Support case insensitive URL pattern

### DIFF
--- a/Sources/Crossroad/Context.swift
+++ b/Sources/Crossroad/Context.swift
@@ -29,8 +29,8 @@ public struct Context<UserInfo> {
         throw Error.parsingArgumentFailed
     }
 
-    public func parameter<T: Extractable>(for key: String, caseInsensitive: Bool = false) -> T? {
-        if let queryItem = queryItem(from: key, caseInsensitive: caseInsensitive) {
+    public func parameter<T: Extractable>(for key: String) -> T? {
+        if let queryItem = queryItem(from: key) {
             if let queryValue = queryItem.value,
                 let value = T.extract(from: queryValue) {
                 return value
@@ -49,15 +49,11 @@ public struct Context<UserInfo> {
         return nil
     }
 
-    private func queryItem(from key: String, caseInsensitive: Bool) -> URLQueryItem? {
-        func isEqual(_ lhs: String, _ rhs: String, caseInsensitive: Bool) -> Bool {
-            if caseInsensitive {
-                return lhs.lowercased() == rhs.lowercased()
-            } else {
-                return lhs == rhs
-            }
+    private func queryItem(from key: String) -> URLQueryItem? {
+        func isEqual(_ lhs: String, _ rhs: String) -> Bool {
+            return lhs.lowercased() == rhs.lowercased()
         }
-        return parameters.first { isEqual($0.name, key, caseInsensitive: caseInsensitive) }
+        return parameters.first { isEqual($0.name, key) }
     }
 
     private func queryItem(matchesIn regexp: NSRegularExpression) -> URLQueryItem? {

--- a/Sources/Crossroad/PatternURL.swift
+++ b/Sources/Crossroad/PatternURL.swift
@@ -14,7 +14,8 @@ internal struct PatternURL {
     private static let pathSeparator = "/"
 
     init?(string: String) {
-        let firstSplit = string.components(separatedBy: PatternURL.schemeSeparator)
+        self.patternString = string.lowercased()
+        let firstSplit = patternString.components(separatedBy: PatternURL.schemeSeparator)
         guard let scheme = firstSplit.first, !scheme.isEmpty else {
             return nil
         }
@@ -25,7 +26,6 @@ internal struct PatternURL {
         }
         self.scheme = scheme
         self.host = host
-        self.patternString = string
         if components.count > 1 {
             let left = components[1 ..< components.count]
             // In URL, pathComponents includes the starting "/" so do the same.

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -11,7 +11,7 @@ public final class Router<UserInfo> {
     private var routes: [Route<UserInfo>] = []
 
     public init(scheme: String) {
-        prefix = .scheme(scheme)
+        prefix = .scheme(scheme.lowercased())
     }
 
     public init(url: URL) {
@@ -27,15 +27,6 @@ public final class Router<UserInfo> {
         }
     }
 
-    private func canRespond(to url: URL) -> Bool {
-        switch prefix {
-        case .scheme(let scheme):
-            return scheme == url.scheme
-        case .url(let prefixURL):
-            return url.absoluteString.hasPrefix(prefixURL.absoluteString)
-        }
-    }
-
     internal func register(_ route: Route<UserInfo>) {
         if isValidURLPattern(route.patternURL) {
             routes.append(route)
@@ -46,16 +37,10 @@ public final class Router<UserInfo> {
 
     @discardableResult
     public func openIfPossible(_ url: URL, userInfo: UserInfo) -> Bool {
-        if !canRespond(to: url) {
-            return false
-        }
         return routes.first { $0.openIfPossible(url, userInfo: userInfo) } != nil
     }
 
     public func responds(to url: URL, userInfo: UserInfo) -> Bool {
-        if !canRespond(to: url) {
-            return false
-        }
         return routes.first { $0.responds(to: url, userInfo: userInfo) } != nil
     }
 

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -56,13 +56,13 @@ public final class Router<UserInfo> {
             let patternURLString: String
             switch prefix {
             case .scheme(let scheme):
-                if pattern.hasPrefix("\(scheme)://") {
+                if pattern.lowercased().hasPrefix("\(scheme)://") {
                     patternURLString = canonicalizePattern(pattern)
                 } else {
                     patternURLString = "\(scheme)://\(canonicalizePattern(pattern))"
                 }
             case .url(let url):
-                if pattern.hasPrefix(url.absoluteString) {
+                if pattern.lowercased().hasPrefix(url.absoluteString) {
                     patternURLString = canonicalizePattern(pattern)
                 } else {
                     patternURLString = url.appendingPathComponent(canonicalizePattern(pattern)).absoluteString

--- a/Sources/Crossroad/URLParser.swift
+++ b/Sources/Crossroad/URLParser.swift
@@ -2,10 +2,11 @@ import Foundation
 
 public struct URLParser<UserInfo> {
     func parse(_ url: URL, in patternURL: PatternURL, userInfo: UserInfo) -> Context<UserInfo>? {
-        guard let scheme = url.scheme, let host = url.host else {
+        let caseInsensitiveURL = URL(string: url.absoluteString.lowercased()) ?? url
+        guard let scheme = caseInsensitiveURL.scheme, let host = caseInsensitiveURL.host else {
             return nil
         }
-        if scheme != patternURL.scheme || patternURL.pathComponents.count != url.pathComponents.count {
+        if scheme != patternURL.scheme || patternURL.pathComponents.count != caseInsensitiveURL.pathComponents.count {
             return nil
         }
 
@@ -17,7 +18,7 @@ public struct URLParser<UserInfo> {
             return nil
         }
 
-        for (patternComponent, component) in zip(patternURL.pathComponents, url.pathComponents) {
+        for (patternComponent, component) in zip(patternURL.pathComponents, caseInsensitiveURL.pathComponents) {
             if patternComponent.hasPrefix(PatternURL.keywordPrefix) {
                 let keyword = String(patternComponent[PatternURL.keywordPrefix.endIndex...])
                 arguments[keyword] = component
@@ -28,12 +29,12 @@ public struct URLParser<UserInfo> {
             }
         }
         let parameters: Parameters
-        if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+        if let components = URLComponents(url: caseInsensitiveURL, resolvingAgainstBaseURL: true) {
             parameters = components.queryItems ?? []
         } else {
             parameters = []
         }
-        return Context<UserInfo>(url: url, arguments: arguments, parameters: parameters, userInfo: userInfo)
+        return Context<UserInfo>(url: caseInsensitiveURL, arguments: arguments, parameters: parameters, userInfo: userInfo)
     }
 }
 

--- a/Sources/Crossroad/URLParser.swift
+++ b/Sources/Crossroad/URLParser.swift
@@ -2,39 +2,38 @@ import Foundation
 
 public struct URLParser<UserInfo> {
     func parse(_ url: URL, in patternURL: PatternURL, userInfo: UserInfo) -> Context<UserInfo>? {
-        let caseInsensitiveURL = URL(string: url.absoluteString.lowercased()) ?? url
-        guard let scheme = caseInsensitiveURL.scheme, let host = caseInsensitiveURL.host else {
+        guard let scheme = url.scheme, let host = url.host else {
             return nil
         }
-        if scheme != patternURL.scheme || patternURL.pathComponents.count != caseInsensitiveURL.pathComponents.count {
+        if scheme.lowercased() != patternURL.scheme || patternURL.pathComponents.count != url.pathComponents.count {
             return nil
         }
 
         var arguments: Arguments = [:]
         if patternURL.host.hasPrefix(PatternURL.keywordPrefix) {
             let keyword = String(patternURL.host[PatternURL.keywordPrefix.endIndex...])
-            arguments[keyword] = host
-        } else if host != patternURL.host {
+            arguments[keyword] = url.host
+        } else if host.lowercased() != patternURL.host {
             return nil
         }
 
-        for (patternComponent, component) in zip(patternURL.pathComponents, caseInsensitiveURL.pathComponents) {
+        for (patternComponent, component) in zip(patternURL.pathComponents, url.pathComponents) {
             if patternComponent.hasPrefix(PatternURL.keywordPrefix) {
                 let keyword = String(patternComponent[PatternURL.keywordPrefix.endIndex...])
                 arguments[keyword] = component
-            } else if patternComponent == component {
+            } else if patternComponent == component.lowercased() {
                 continue
             } else {
                 return nil
             }
         }
         let parameters: Parameters
-        if let components = URLComponents(url: caseInsensitiveURL, resolvingAgainstBaseURL: true) {
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
             parameters = components.queryItems ?? []
         } else {
             parameters = []
         }
-        return Context<UserInfo>(url: caseInsensitiveURL, arguments: arguments, parameters: parameters, userInfo: userInfo)
+        return Context<UserInfo>(url: url, arguments: arguments, parameters: parameters, userInfo: userInfo)
     }
 }
 

--- a/Tests/CrossroadTests/ContextTests.swift
+++ b/Tests/CrossroadTests/ContextTests.swift
@@ -31,9 +31,8 @@ final class ContextTests: XCTestCase {
         XCTAssertEqual(context.parameter(for: "name"), "Pikachu")
         XCTAssertNil(context.parameter(for: "foo") as String?)
         XCTAssertEqual(context.parameter(for: "region"), Region.kanto)
-        XCTAssertNil(context.parameter(for: "NaMe") as String?)
-        XCTAssertEqual(context.parameter(for: "NaMe", caseInsensitive: true), "Pikachu")
-        XCTAssertEqual(context.parameter(for: "NAME2", caseInsensitive: true), "Mewtwo")
+        XCTAssertEqual(context.parameter(for: "NaMe"), "Pikachu")
+        XCTAssertEqual(context.parameter(for: "NAME2"), "Mewtwo")
     }
 
     func testParametersByRegexp() {

--- a/Tests/CrossroadTests/PatternURLTests.swift
+++ b/Tests/CrossroadTests/PatternURLTests.swift
@@ -24,6 +24,15 @@ final class PatternURLTests: XCTestCase {
         XCTAssertEqual(patternURL.pathComponents, [])
     }
 
+    func testCapitalCase() {
+        let subject = PatternURL(string: "FOOBAR://FOO/BAR")!
+        XCTAssertEqual(subject.patternString,
+                       "foobar://foo/bar")
+        XCTAssertEqual(subject.scheme, "foobar")
+        XCTAssertEqual(subject.host, "foo")
+        XCTAssertEqual(subject.pathComponents, ["/", "bar"])
+    }
+
     func testParseWithKeyword() {
         let url0 = PatternURL(string: "foobar://search/:keyword")
         XCTAssertEqual(url0?.scheme, "foobar")

--- a/Tests/CrossroadTests/RouterTests.swift
+++ b/Tests/CrossroadTests/RouterTests.swift
@@ -10,7 +10,7 @@ final class RouterTest: XCTestCase {
         router.register([
             ("foobar://static", { _ in true }),
             ("foobar://foo/bar", { _ in true }),
-            ("foobar://spam/ham", { _ in false }),
+            ("FOOBAR://SPAM/HAM", { _ in false }),
             ("foobar://:keyword", { _ in true }),
             ("foobar://foo/:keyword", { _ in true }),
             ])
@@ -35,7 +35,7 @@ final class RouterTest: XCTestCase {
         router.register([
             ("foobar://static", { _ in true }),
             ("foobar://foo/bar", { _ in true }),
-            ("foobar://spam/ham", { _ in false }),
+            ("FOOBAR://SPAM/HAM", { _ in false }),
             ("foobar://:keyword", { _ in true }),
             ("foobar://foo/:keyword", { _ in true }),
             ])
@@ -60,7 +60,7 @@ final class RouterTest: XCTestCase {
         router.register([
             ("https://example.com/static", { _ in true }),
             ("https://example.com/foo/bar", { _ in true }),
-            ("https://example.com/spam/ham", { _ in false }),
+            ("HTTPS://EXAMPLE.COM/SPAM/HAM", { _ in false }),
             ("https://example.com/:keyword", { _ in true }),
             ("https://example.com/foo/:keyword", { _ in true }),
             ])
@@ -84,7 +84,7 @@ final class RouterTest: XCTestCase {
         router.register([
             ("static", { _ in true }),
             ("foo/bar", { _ in true }),
-            ("spam/ham", { _ in false }),
+            ("SPAM/HAM", { _ in false }),
             (":keyword", { _ in true }),
             ("foo/:keyword", { _ in true }),
             ])
@@ -108,7 +108,7 @@ final class RouterTest: XCTestCase {
         router.register([
             ("/static", { _ in true }),
             ("/foo/bar", { _ in true }),
-            ("/spam/ham", { _ in false }),
+            ("/SPAM/HAM", { _ in false }),
             ("/:keyword", { _ in true }),
             ("/foo/:keyword", { _ in true }),
             ])
@@ -132,7 +132,7 @@ final class RouterTest: XCTestCase {
         router.register([
             ("static", { _ in true }),
             ("foo/bar", { _ in true }),
-            ("spam/ham", { _ in false }),
+            ("SPAM/HAM", { _ in false }),
             (":keyword", { _ in true }),
             ("foo/:keyword", { _ in true }),
             ])

--- a/Tests/CrossroadTests/RouterTests.swift
+++ b/Tests/CrossroadTests/RouterTests.swift
@@ -30,16 +30,16 @@ final class RouterTest: XCTestCase {
         XCTAssertFalse(router.responds(to: URL(string: "spam/ham")!))
     }
 
-    func _testCanRespondWithCapitalCase() {
+    func testCanRespondWithCapitalCase() {
         let router = SimpleRouter(scheme: "FOOBAR")
         router.register([
-            ("foobar://static", { _ in true }),
-            ("foobar://foo/bar", { _ in true }),
+            ("FOOBAR://STATIC", { _ in true }),
+            ("FOOBAR://FOO/BAR", { _ in true }),
             ("FOOBAR://SPAM/HAM", { _ in false }),
-            ("foobar://:keyword", { _ in true }),
-            ("foobar://foo/:keyword", { _ in true }),
+            ("FOOBAR://:keyword", { _ in true }),
+            ("FOOBAR://FOO/:keyword", { _ in true }),
             ])
-        XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://sTATic")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
         XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))

--- a/Tests/CrossroadTests/RouterTests.swift
+++ b/Tests/CrossroadTests/RouterTests.swift
@@ -241,7 +241,7 @@ final class RouterTest: XCTestCase {
     func testHandleWithoutPrefix() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler four times")
-        expectation.expectedFulfillmentCount = 5
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("static", { context in
                 XCTAssertEqual(context.url, URL(string: "foobar://static")!)
@@ -255,8 +255,8 @@ final class RouterTest: XCTestCase {
                 return true
             }),
             (":keyword", { context in
-                XCTAssertEqual(context.url, URL(string: "foobar://hoge")!)
-                XCTAssertEqual(try? context.argument(for: "keyword"), "hoge")
+                XCTAssertEqual(context.url, URL(string: "FOOBAR://HOGE")!)
+                XCTAssertEqual(try? context.argument(for: "keyword"), "HOGE")
                 expectation.fulfill()
                 return true
             }),
@@ -270,7 +270,6 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar?param0=123")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://hoge")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://HOGE")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/hoge/fuga")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foobar://spam/ham")!))
@@ -286,7 +285,7 @@ final class RouterTest: XCTestCase {
     func testHandleWithSlashPrefix() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler four times")
-        expectation.expectedFulfillmentCount = 5
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("/static", { context in
                 XCTAssertEqual(context.url, URL(string: "foobar://static")!)
@@ -300,8 +299,8 @@ final class RouterTest: XCTestCase {
                 return true
             }),
             ("/:keyword", { context in
-                XCTAssertEqual(context.url, URL(string: "foobar://hoge")!)
-                XCTAssertEqual(try? context.argument(for: "keyword"), "hoge")
+                XCTAssertEqual(context.url, URL(string: "FOOBAR://HOGE")!)
+                XCTAssertEqual(try? context.argument(for: "keyword"), "HOGE")
                 expectation.fulfill()
                 return true
             }),
@@ -315,7 +314,6 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar?param0=123")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://hoge")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://HOGE")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/hoge/fuga")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foobar://spam/ham")!))
@@ -331,7 +329,7 @@ final class RouterTest: XCTestCase {
     func testHandleWithoutPrefixWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com")!)
         let expectation = self.expectation(description: "Should called handler four times")
-        expectation.expectedFulfillmentCount = 5
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("static", { context in
                 XCTAssertEqual(context.url, URL(string: "https://example.com/static")!)
@@ -345,8 +343,8 @@ final class RouterTest: XCTestCase {
                 return true
             }),
             (":keyword", { context in
-                XCTAssertEqual(context.url, URL(string: "https://example.com/hoge")!)
-                XCTAssertEqual(try? context.argument(for: "keyword"), "hoge")
+                XCTAssertEqual(context.url, URL(string: "https://example.com/HOGE")!)
+                XCTAssertEqual(try? context.argument(for: "keyword"), "HOGE")
                 expectation.fulfill()
                 return true
             }),
@@ -360,7 +358,6 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/static")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar?param0=123")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/hoge")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/HOGE")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/hoge/fuga")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "https://example.com/spam/ham")!))
@@ -377,7 +374,6 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(scheme: scheme)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
-        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("foobar://foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -390,14 +386,13 @@ final class RouterTest: XCTestCase {
             }),
             ("foobar://foo/:keyword", { context in
                 let keyword: String = try! context.argument(for: "keyword")
-                XCTAssertEqual(context.url, URL(string: "foobar://foo/bar")!)
-                XCTAssertEqual(keyword, "bar")
+                XCTAssertEqual(context.url, URL(string: "FOOBAR://FOO/BAR")!)
+                XCTAssertEqual(keyword, "BAR")
                 keywordExpectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/42")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
@@ -408,7 +403,6 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
-        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("https://example.com/foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -421,14 +415,13 @@ final class RouterTest: XCTestCase {
             }),
             ("https://example.com/foo/:keyword", { context in
                 let keyword: String = try! context.argument(for: "keyword")
-                XCTAssertEqual(context.url, URL(string: "https://example.com/foo/bar")!)
-                XCTAssertEqual(keyword, "bar")
+                XCTAssertEqual(context.url, URL(string: "https://example.com/FOO/BAR")!)
+                XCTAssertEqual(keyword, "BAR")
                 keywordExpectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/42")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
@@ -439,7 +432,6 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(scheme: scheme)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
-        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -452,14 +444,13 @@ final class RouterTest: XCTestCase {
             }),
             ("foo/:keyword", { context in
                 let keyword: String = try! context.argument(for: "keyword")
-                XCTAssertEqual(context.url, URL(string: "foobar://foo/bar")!)
-                XCTAssertEqual(keyword, "bar")
+                XCTAssertEqual(context.url, URL(string: "FOOBAR://FOO/BAR")!)
+                XCTAssertEqual(keyword, "BAR")
                 keywordExpectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/42")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
@@ -470,7 +461,6 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
-        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -483,14 +473,13 @@ final class RouterTest: XCTestCase {
             }),
             ("foo/:keyword", { context in
                 let keyword: String = try! context.argument(for: "keyword")
-                XCTAssertEqual(context.url, URL(string: "https://example.com/foo/bar")!)
-                XCTAssertEqual(keyword, "bar")
+                XCTAssertEqual(context.url, URL(string: "https://example.com/FOO/BAR")!)
+                XCTAssertEqual(keyword, "BAR")
                 keywordExpectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/42")!))
-        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
@@ -500,19 +489,18 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalse() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 2
         router.register([
             ("foobar://foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
             ("/foo/:keyword", { context in
-                XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
+                XCTAssertEqual(try? context.argument(for: "keyword"), "BAR")
                 expectation.fulfill()
                 return true
             }),
             ])
-        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
@@ -521,19 +509,18 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalseWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 2
         router.register([
             ("https://example.com/foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
             ("/foo/:keyword", { context in
-                XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
+                XCTAssertEqual(try? context.argument(for: "keyword"), "BAR")
                 expectation.fulfill()
                 return true
             }),
             ])
-        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
@@ -542,19 +529,18 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalseWithoutPrefix() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 2
         router.register([
             ("foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
             ("/foo/:keyword", { context in
-                XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
+                XCTAssertEqual(try? context.argument(for: "keyword"), "BAR")
                 expectation.fulfill()
                 return true
             }),
             ])
-        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
@@ -563,19 +549,18 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalseWithoutPrefixWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 2
         router.register([
             ("foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
             ("/foo/:keyword", { context in
-                XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
+                XCTAssertEqual(try? context.argument(for: "keyword"), "BAR")
                 expectation.fulfill()
                 return true
             }),
             ])
-        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)

--- a/Tests/CrossroadTests/RouterTests.swift
+++ b/Tests/CrossroadTests/RouterTests.swift
@@ -546,6 +546,21 @@ final class RouterTest: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
 
+    func testHandleCapitalCasedHostKeyword() {
+        let router = SimpleRouter(scheme: scheme)
+        let expectation = self.expectation(description: "Should called handler")
+        router.register([
+            (":keyword", { context in
+                XCTAssertEqual(context.url.absoluteString, "FOOBAR://FOO")
+                XCTAssertEqual(try! context.argument(for: "keyword"), "FOO")
+                expectation.fulfill()
+                return true
+            }),
+        ])
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO")!))
+        wait(for: [expectation], timeout: 2.0)
+    }
+
     func testHandleReturnsFalseWithoutPrefixWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let expectation = self.expectation(description: "Should called handler twice")

--- a/Tests/CrossroadTests/RouterTests.swift
+++ b/Tests/CrossroadTests/RouterTests.swift
@@ -17,6 +17,32 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.responds(to: URL(string: "static")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/bar")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "spam/ham")!))
+    }
+
+    func _testCanRespondWithCapitalCase() {
+        let router = SimpleRouter(scheme: "FOOBAR")
+        router.register([
+            ("foobar://static", { _ in true }),
+            ("foobar://foo/bar", { _ in true }),
+            ("foobar://spam/ham", { _ in false }),
+            ("foobar://:keyword", { _ in true }),
+            ("foobar://foo/:keyword", { _ in true }),
+            ])
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
         XCTAssertFalse(router.responds(to: URL(string: "foobar://aaa/bbb")!))
         XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
@@ -65,6 +91,7 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
         XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://spam/ham")!))
@@ -88,6 +115,7 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
         XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
         XCTAssertTrue(router.responds(to: URL(string: "foobar://spam/ham")!))
@@ -213,7 +241,7 @@ final class RouterTest: XCTestCase {
     func testHandleWithoutPrefix() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler four times")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 5
         router.register([
             ("static", { context in
                 XCTAssertEqual(context.url, URL(string: "foobar://static")!)
@@ -243,6 +271,7 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar?param0=123")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://HOGE")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/hoge/fuga")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foobar://spam/ham")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "notfoobar://static")!))
@@ -257,7 +286,7 @@ final class RouterTest: XCTestCase {
     func testHandleWithSlashPrefix() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler four times")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 5
         router.register([
             ("/static", { context in
                 XCTAssertEqual(context.url, URL(string: "foobar://static")!)
@@ -287,6 +316,7 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar?param0=123")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://HOGE")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/hoge/fuga")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foobar://spam/ham")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "notfoobar://static")!))
@@ -301,7 +331,7 @@ final class RouterTest: XCTestCase {
     func testHandleWithoutPrefixWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com")!)
         let expectation = self.expectation(description: "Should called handler four times")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 5
         router.register([
             ("static", { context in
                 XCTAssertEqual(context.url, URL(string: "https://example.com/static")!)
@@ -331,6 +361,7 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/static")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar?param0=123")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/HOGE")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/hoge/fuga")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "https://example.com/spam/ham")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "nothttps://example.com/static")!))
@@ -346,6 +377,7 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(scheme: scheme)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
+        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("foobar://foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -366,6 +398,7 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/42")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [idExpectation, keywordExpectation], timeout: 2.0)
@@ -375,6 +408,7 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
+        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("https://example.com/foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -395,6 +429,7 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/42")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [idExpectation, keywordExpectation], timeout: 2.0)
@@ -404,6 +439,7 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(scheme: scheme)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
+        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -424,6 +460,7 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/42")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [idExpectation, keywordExpectation], timeout: 2.0)
@@ -433,6 +470,7 @@ final class RouterTest: XCTestCase {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let idExpectation = self.expectation(description: "Should called handler with ID")
         let keywordExpectation = self.expectation(description: "Should called handler with keyword")
+        keywordExpectation.expectedFulfillmentCount = 2
         router.register([
             ("foo/:id", { context in
                 guard let id: Int = try? context.argument(for: "id") else {
@@ -453,6 +491,7 @@ final class RouterTest: XCTestCase {
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/42")!))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/42")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [idExpectation, keywordExpectation], timeout: 2.0)
@@ -461,19 +500,20 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalse() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 2
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("foobar://foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
-            ("foobar://foo/:keyword", { context in
+            ("/foo/:keyword", { context in
                 XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
                 expectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
     }
@@ -481,19 +521,20 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalseWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 2
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("https://example.com/foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
-            ("https://example.com/foo/:keyword", { context in
+            ("/foo/:keyword", { context in
                 XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
                 expectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
     }
@@ -501,19 +542,20 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalseWithoutPrefix() {
         let router = SimpleRouter(scheme: scheme)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 2
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
-            ("foo/:keyword", { context in
+            ("/foo/:keyword", { context in
                 XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
                 expectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
     }
@@ -521,19 +563,20 @@ final class RouterTest: XCTestCase {
     func testHandleReturnsFalseWithoutPrefixWithURLPrefix() {
         let router = SimpleRouter(url: URL(string: "https://example.com/")!)
         let expectation = self.expectation(description: "Should called handler twice")
-        expectation.expectedFulfillmentCount = 2
+        expectation.expectedFulfillmentCount = 4
         router.register([
             ("foo/bar", { _ in
                 expectation.fulfill()
                 return false
             }),
-            ("foo/:keyword", { context in
+            ("/foo/:keyword", { context in
                 XCTAssertEqual(try? context.argument(for: "keyword"), "bar")
                 expectation.fulfill()
                 return true
             }),
             ])
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/FOO/BAR")!))
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
     }


### PR DESCRIPTION
According to [RFC-3986](https://tools.ietf.org/html/rfc3986), URL must be case-insensitive.

When opening App from capital-cased URL Scheme, Currently, Crossroad couldn't handle them.

```swift
router.register("myapp://users/:id", { return true })
router.openIfPosible(URL(string: "MYAPP://USERS/10"))!
```

Crossroad 3 can treat URL as case insensitive.
And remove `caseInsensitive` options from `Context`.