### PR TITLE
Add Module stability

### DIFF
--- a/Crossroad.xcodeproj/project.pbxproj
+++ b/Crossroad.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		546DEA8F20AD77F800923325 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -420,6 +421,7 @@
 		546DEA9020AD77F800923325 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
Add compile option for convenience `BUILD_LIBRARY_FOR_DISTRIBUTION = YES`.
The difference of swift version can be ignore with this option.

I referenced this commit.
https://github.com/kishikawakatsumi/KeychainAccess/commit/e20f21f208f1e291500fe569094597a8a1062a2f#diff-58bea6d1dedfc8e4cf8e734d08980dd0