### PR TITLE
Include instructions for scene delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
 }
 ```
 
+Or, if you are using `SceneDelegate` with a modern app:
+
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else {
+            print("No url")
+            return
+        }
+        _ = router.openIfPossible(url, options: Dictionary<UIApplication.OpenURLOptionsKey, Any>())
+    }
+```
+
 ## Argument and Parameter
 
 `:` prefixed components on passed URL pattern mean **argument**.


### PR DESCRIPTION
New projects since iOS 13 include a scene delegate and the provided instructions don't work in such cases.