### PR TITLE
Assert failuer with duplicate routing

### DIFF
--- a/Sources/Crossroad/PatternURL.swift
+++ b/Sources/Crossroad/PatternURL.swift
@@ -44,3 +44,12 @@ internal struct PatternURL {
         return patternString.lowercased().hasPrefix(url.absoluteString.lowercased())
     }
 }
+
+extension PatternURL: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.host == rhs.host &&
+            lhs.scheme == rhs.scheme &&
+            lhs.pathComponents == rhs.pathComponents &&
+            lhs.patternString == rhs.patternString
+    }
+}

--- a/Sources/Crossroad/PatternURL.swift
+++ b/Sources/Crossroad/PatternURL.swift
@@ -44,4 +44,3 @@ internal struct PatternURL: Hashable {
         return patternString.lowercased().hasPrefix(url.absoluteString.lowercased())
     }
 }
-

--- a/Sources/Crossroad/PatternURL.swift
+++ b/Sources/Crossroad/PatternURL.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // A ':' in the host name is not a valid URL (as : is for the port) so we cannot use Foundation's URL for the pattern and have to parse it ourselves.
 // Note that it's very simple and do not allow complicated patterns with for example queries.
-internal struct PatternURL {
+internal struct PatternURL: Hashable {
     static let keywordPrefix = ":"
 
     let scheme: String
@@ -45,11 +45,3 @@ internal struct PatternURL {
     }
 }
 
-extension PatternURL: Equatable {
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.host == rhs.host &&
-            lhs.scheme == rhs.scheme &&
-            lhs.pathComponents == rhs.pathComponents &&
-            lhs.patternString == rhs.patternString
-    }
-}

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -28,6 +28,11 @@ public final class Router<UserInfo> {
     }
 
     internal func register(_ route: Route<UserInfo>) {
+        if routes.contains(where: { element in
+            element.patternURL == route.patternURL
+        }) {
+            assertionFailure("\(route.patternURL) is already registered")
+        }
         if isValidURLPattern(route.patternURL) {
             routes.append(route)
         } else {
@@ -73,12 +78,6 @@ public final class Router<UserInfo> {
                 continue
             }
             let route = Route(pattern: patternURL, handler: handler)
-            if self.routes.contains(where: { element in
-                element.patternURL == route.patternURL
-            }) {
-                assertionFailure("\(pattern) is already registered")
-                continue
-            }
             register(route)
         }
     }

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -73,6 +73,12 @@ public final class Router<UserInfo> {
                 continue
             }
             let route = Route(pattern: patternURL, handler: handler)
+            if self.routes.contains(where: { element in
+                element.patternURL == route.patternURL
+            }) {
+                assertionFailure("\(pattern) is already registered")
+                continue
+            }
             register(route)
         }
     }

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -31,7 +31,7 @@ public final class Router<UserInfo> {
         if routes.contains(where: { element in
             element.patternURL == route.patternURL
         }) {
-            assertionFailure("\(route.patternURL) is already registered")
+            assertionFailure("\(route.patternURL.patternString) is already registered")
         }
         if isValidURLPattern(route.patternURL) {
             routes.append(route)


### PR DESCRIPTION
Added `assertionFailure` with duplicate routing.

Currently if there is a duplication of routing, one is ignored and the other works. So if we accidentally define duplicate routes, we won't notice unnecessary code.