### PR TITLE
Change HostRunner name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: Crossroad
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   iOS:
-    runs-on: macos
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Run Tests
@@ -12,7 +12,7 @@ jobs:
         DESTINATION="platform=iOS Simulator,name=iPhone 8" SCHEME="Crossroad-iOS"
         xcodebuild test -project Crossroad.xcodeproj -scheme "${SCHEME}" -destination "${DESTINATION}"
   tvOS:
-    runs-on: macos
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Run Tests
@@ -20,7 +20,7 @@ jobs:
         DESTINATION="platform=tvOS Simulator,name=Apple TV 4K" SCHEME="Crossroad-tvOS"
         xcodebuild test -project Crossroad.xcodeproj -scheme "${SCHEME}" -destination "${DESTINATION}"
   Lint:
-    runs-on: macos
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       run: |
         gem install cocoapods
         pod repo update
-        brew link --overwrite swiftlint || brew install swiftlint
     - name: SwiftLint
       run: swiftlint --strict
     - name: CocoaPods

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         gem install cocoapods
         pod repo update
-        brew install swiftlint
+        brew link --overwrite swiftlint || brew install swiftlint
     - name: SwiftLint
       run: swiftlint --strict
     - name: CocoaPods


### PR DESCRIPTION
The master build fails with error that `No runner matching the specified labels was found: macos.`.
Fixed hosted runner label to `macos-latest`.
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

I also added workflow trigger event `pull_request` to notify the pull request author when build fails.
