### PR TITLE
Allows Router to handle multiple prefix (Universal Links and Custom URL Scheme) in one object

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Of course, you can also use [Firebase Dynamic Link](https://firebase.google.com/
 ```swift
 let router = DefaultRouter(url: URL(string: "https://my-awesome-pokedex.com")!)
 ```
+
 ## Universal Links and Custom URL Scheme.
 
 You can also make routers handle with both Universal Links and Custom URL Scheme.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,23 @@ Of course, you can also use [Firebase Dynamic Link](https://firebase.google.com/
 ```swift
 let router = DefaultRouter(url: URL(string: "https://my-awesome-pokedex.com")!)
 ```
+## Universal Links and Custom URL Scheme.
+
+You can also make routers handle with both Universal Links and Custom URL Scheme.
+
+```swift
+let router = DefaultRouter(scheme: "pokedex", url: URL(string: "https://my-awesome-pokedex.com")!)
+
+router.register([
+    ("/pokemons", { context in 
+        ...
+    }),
+    ("/pokemons/:pokedexID", { context in 
+        ...
+    }),
+    // ...
+])
+```
 
 ## Parse URL patterns
 

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -81,32 +81,28 @@ public final class Router<UserInfo> {
 
     public func register(_ routes: [(String, Route<UserInfo>.Handler)]) {
         for (pattern, handler) in routes {
-            var routes: [Route<UserInfo>] = []
             switch prefix {
             case .scheme(let scheme):
                 guard let patternSchemeURL = PatternURL(string: generatePatternURLString(from: pattern, scheme: scheme)) else {
                     assertionFailure("\(pattern) is invalid")
                     continue
                 }
-                routes.append(Route(pattern: patternSchemeURL, handler: handler))
+                register(Route(pattern: patternSchemeURL, handler: handler))
             case .url(let url):
                 guard let patternURL = PatternURL(string: generatePatternURLString(from: pattern, url: url)) else {
                     assertionFailure("\(pattern) is invalid")
                     continue
                 }
-                routes.append(Route(pattern: patternURL, handler: handler))
+                register(Route(pattern: patternURL, handler: handler))
             case .multiple(scheme: let scheme, url: let url):
                 guard let patternSchemeURL = PatternURL(string: generatePatternURLString(from: pattern, scheme: scheme)),
                       let patternURL = PatternURL(string: generatePatternURLString(from: pattern, url: url)) else {
                     assertionFailure("\(pattern) is invalid")
                     continue
                 }
-                routes.append(contentsOf: [
-                    Route(pattern: patternURL, handler: handler),
-                    Route(pattern: patternSchemeURL, handler: handler)
-                ])
+                register(Route(pattern: patternURL, handler: handler))
+                register(Route(pattern: patternSchemeURL, handler: handler))
             }
-            routes.forEach(register)
         }
     }
 }

--- a/Sources/Crossroad/Router.swift
+++ b/Sources/Crossroad/Router.swift
@@ -63,7 +63,7 @@ public final class Router<UserInfo> {
         return pattern
     }
     
-    private func generatePatternURLString(from pattern: String, scheme: String) -> String {
+    private func createCustomSchemeURLString(from pattern: String, scheme: String) -> String {
         if pattern.lowercased().hasPrefix("\(scheme)://") {
             return canonicalizePattern(pattern)
         } else {
@@ -71,7 +71,7 @@ public final class Router<UserInfo> {
         }
     }
     
-    private func generatePatternURLString(from pattern: String, url: URL) -> String {
+    private func createUniversalLinkURLString(from pattern: String, url: URL) -> String {
         if pattern.lowercased().hasPrefix(url.absoluteString) {
             return canonicalizePattern(pattern)
         } else {
@@ -83,25 +83,25 @@ public final class Router<UserInfo> {
         for (pattern, handler) in routes {
             switch prefix {
             case .scheme(let scheme):
-                guard let patternSchemeURL = PatternURL(string: generatePatternURLString(from: pattern, scheme: scheme)) else {
+                guard let customSchemePatternURL = PatternURL(string: createCustomSchemeURLString(from: pattern, scheme: scheme)) else {
                     assertionFailure("\(pattern) is invalid")
                     continue
                 }
-                register(Route(pattern: patternSchemeURL, handler: handler))
+                register(Route(pattern: customSchemePatternURL, handler: handler))
             case .url(let url):
-                guard let patternURL = PatternURL(string: generatePatternURLString(from: pattern, url: url)) else {
+                guard let universalLinkPatternURL = PatternURL(string: createUniversalLinkURLString(from: pattern, url: url)) else {
                     assertionFailure("\(pattern) is invalid")
                     continue
                 }
-                register(Route(pattern: patternURL, handler: handler))
+                register(Route(pattern: universalLinkPatternURL, handler: handler))
             case .multiple(scheme: let scheme, url: let url):
-                guard let patternSchemeURL = PatternURL(string: generatePatternURLString(from: pattern, scheme: scheme)),
-                      let patternURL = PatternURL(string: generatePatternURLString(from: pattern, url: url)) else {
+                guard let customSchemePatternURL = PatternURL(string: createCustomSchemeURLString(from: pattern, scheme: scheme)),
+                      let universalLinkPatternURL = PatternURL(string: createUniversalLinkURLString(from: pattern, url: url)) else {
                     assertionFailure("\(pattern) is invalid")
                     continue
                 }
-                register(Route(pattern: patternURL, handler: handler))
-                register(Route(pattern: patternSchemeURL, handler: handler))
+                register(Route(pattern: customSchemePatternURL, handler: handler))
+                register(Route(pattern: universalLinkPatternURL, handler: handler))
             }
         }
     }

--- a/Tests/CrossroadTests/RouterTests.swift
+++ b/Tests/CrossroadTests/RouterTests.swift
@@ -3,6 +3,7 @@ import Crossroad
 
 final class RouterTest: XCTestCase {
     let scheme = "foobar"
+    let url = URL(string: "https://example.com/")!
 
     func testCanRespond() {
         let router = SimpleRouter(scheme: scheme)
@@ -148,6 +149,124 @@ final class RouterTest: XCTestCase {
         XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo/10000")!))
         XCTAssertFalse(router.responds(to: URL(string: "nothttps://example.com/aaa/bbb")!))
         XCTAssertFalse(router.responds(to: URL(string: "https://example.com/spam/ham")!))
+        XCTAssertFalse(router.responds(to: URL(string: "static")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/bar")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "spam/ham")!))
+    }
+
+    func testCanRespondMultipe() {
+        let router = SimpleRouter(scheme: scheme, url: url)
+        router.register([
+            ("static", { _ in true }),
+            ("foo/bar", { _ in true }),
+            ("SPAM/HAM", { _ in false }),
+            (":keyword", { _ in true }),
+            ("foo/:keyword", { _ in true }),
+            ])
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://SPAM/ham")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://SPAM/HAM")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://spam/HAM")!))
+        XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://spam/ham")!))
+        
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/FOO/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "nothttps://example.com/aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/spam/ham")!))
+        XCTAssertFalse(router.responds(to: URL(string: "static")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/bar")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "spam/ham")!))
+    }
+
+    func testCanRespondMultipeWithCapitalCase() {
+        let router = SimpleRouter(scheme: "FOOBAR", url: url)
+        router.register([
+            ("STATIC", { _ in true }),
+            ("FOO/BAR", { _ in true }),
+            ("SPAM/HAM", { _ in false }),
+            (":keyword", { _ in true }),
+            ("FOO/:keyword", { _ in true }),
+            ])
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://SPAM/ham")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://SPAM/HAM")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://spam/HAM")!))
+        XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://spam/ham")!))
+        
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/STATIC")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/FOO/BAR")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/FOO/10000")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/sTATIc")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/foo/bar")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "nothttps://example.com/aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/spam/ham")!))
+
+        XCTAssertFalse(router.responds(to: URL(string: "static")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/bar")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "spam/ham")!))
+    }
+
+    func testCanRespondMultipeWithRelativePath() {
+        let router = SimpleRouter(scheme: scheme, url: url)
+        router.register([
+            ("/static", { _ in true }),
+            ("/foo/bar", { _ in true }),
+            ("/SPAM/HAM", { _ in false }),
+            ("/:keyword", { _ in true }),
+            ("/foo/:keyword", { _ in true }),
+            ])
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "FOOBAR://FOO/BAR")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://SPAM/ham")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://SPAM/HAM")!))
+        XCTAssertTrue(router.responds(to: URL(string: "foobar://spam/HAM")!))
+        XCTAssertFalse(router.responds(to: URL(string: "notfoobar://aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "foobar://spam/ham")!))
+        
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/static")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://example.com/foo/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/FOO/10000")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "nothttps://example.com/aaa/bbb")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://example.com/spam/ham")!))
+
         XCTAssertFalse(router.responds(to: URL(string: "static")!))
         XCTAssertFalse(router.responds(to: URL(string: "foo")!))
         XCTAssertFalse(router.responds(to: URL(string: "foo/bar")!))
@@ -586,6 +705,152 @@ final class RouterTest: XCTestCase {
         XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar")!))
         wait(for: [expectation], timeout: 2.0)
     }
+    
+    func testHandleMultiple() {
+        let router = SimpleRouter(scheme: scheme, url: url)
+        let expectation = self.expectation(description: "Should called handler eight times")
+        expectation.expectedFulfillmentCount = 8
+        router.register([
+            ("static", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://static")! || context.url == URL(string: "https://example.com/static")!
+                XCTAssertTrue(isExpectedURL)
+                expectation.fulfill()
+                return true
+            }),
+            ("foo/bar", { context in
+                XCTAssertEqual(context.parameter(for: "param0"), 123)
+                let isExpectedURL = context.url == URL(string: "foobar://foo/bar?param0=123")! || context.url == URL(string: "https://example.com/foo/bar?param0=123")!
+                XCTAssertTrue(isExpectedURL)
+                expectation.fulfill()
+                return true
+            }),
+            (":pokemonName", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://hoge")! || context.url == URL(string: "https://example.com/hoge")!
+                XCTAssertTrue(isExpectedURL)
+                XCTAssertEqual(try? context.argument(for: "pokemonName"), "hoge")
+                expectation.fulfill()
+                return true
+            }),
+            ("foo/:pokemonName/:keyword2", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://foo/hoge/fuga")! || context.url == URL(string: "https://example.com/foo/hoge/fuga")!
+                XCTAssertTrue(isExpectedURL)
+                XCTAssertEqual(try? context.argument(for: "pokemonName"), "hoge")
+                XCTAssertEqual(try? context.argument(for: "keyword2"), "fuga")
+                expectation.fulfill()
+                return true
+            }),
+            ])
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar?param0=123")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/hoge/fuga")!))
+        
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/static")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar?param0=123")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/hoge/fuga")!))
+        
+        XCTAssertFalse(router.openIfPossible(URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "notfoobar://static")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "static")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar?param0=123")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "hoge")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "foo/hoge/fuga")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "spam/ham")!))
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testHandleMultipleWithSlashPrefix() {
+        let router = SimpleRouter(scheme: scheme, url: url)
+        let expectation = self.expectation(description: "Should called handler eight times")
+        expectation.expectedFulfillmentCount = 8
+        router.register([
+            ("/static", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://static")! || context.url == URL(string: "https://example.com/static")!
+                XCTAssertTrue(isExpectedURL)
+                expectation.fulfill()
+                return true
+            }),
+            ("/foo/bar", { context in
+                XCTAssertEqual(context.parameter(for: "param0"), 123)
+                let isExpectedURL = context.url == URL(string: "foobar://foo/bar?param0=123")! || context.url == URL(string: "https://example.com/foo/bar?param0=123")!
+                XCTAssertTrue(isExpectedURL)
+                expectation.fulfill()
+                return true
+            }),
+            ("/:pokemonName", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://hoge")! || context.url == URL(string: "https://example.com/hoge")!
+                XCTAssertTrue(isExpectedURL)
+                XCTAssertEqual(try? context.argument(for: "pokemonName"), "hoge")
+                expectation.fulfill()
+                return true
+            }),
+            ("/foo/:pokemonName/:keyword2", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://foo/hoge/fuga")! || context.url == URL(string: "https://example.com/foo/hoge/fuga")!
+                XCTAssertTrue(isExpectedURL)
+                XCTAssertEqual(try? context.argument(for: "pokemonName"), "hoge")
+                XCTAssertEqual(try? context.argument(for: "keyword2"), "fuga")
+                expectation.fulfill()
+                return true
+            }),
+            ])
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/bar?param0=123")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://foo/hoge/fuga")!))
+        
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/static")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/bar?param0=123")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/hoge")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/foo/hoge/fuga")!))
+        
+        XCTAssertFalse(router.openIfPossible(URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "notfoobar://static")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "static")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "foo/bar?param0=123")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "hoge")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "foo/hoge/fuga")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "spam/ham")!))
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testHandleMultipleReturnsFalse() {
+        let router = SimpleRouter(scheme: scheme, url: url)
+        let expectation = self.expectation(description: "Should called handler twice")
+        expectation.expectedFulfillmentCount = 4
+        router.register([
+            ("foo/bar", { _ in
+                expectation.fulfill()
+                return false
+            }),
+            ("/spam/:matchingKeyword", { context in
+                XCTAssertEqual(try? context.argument(for: "matchingKeyword"), "ham")
+                expectation.fulfill()
+                return true
+            }),
+            ])
+        XCTAssertFalse(router.openIfPossible(URL(string: "foobar://foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://spam/ham")!))
+        XCTAssertFalse(router.openIfPossible(URL(string: "https://example.com/foo/bar")!))
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/spam/ham")!))
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testHandleMultipleCapitalCasedHostKeyword() {
+        let router = SimpleRouter(scheme: scheme, url: url)
+        let expectation = self.expectation(description: "Should called handler")
+        router.register([
+            (":pokemonName", { context in
+                XCTAssertEqual(context.url.absoluteString, "FOOBAR://FOO")
+                XCTAssertEqual(try! context.argument(for: "pokemonName"), "FOO")
+                expectation.fulfill()
+                return true
+            }),
+        ])
+        XCTAssertTrue(router.openIfPossible(URL(string: "FOOBAR://FOO")!))
+        wait(for: [expectation], timeout: 2.0)
+    }
+
 
     func testWithUserInfo() {
         struct UserInfo {
@@ -654,6 +919,26 @@ final class RouterTest: XCTestCase {
                 return true
             }),
             ])
+        XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/static")!, userInfo: UserInfo(value: 42)))
+        XCTAssertFalse(router.openIfPossible(URL(string: "static")!, userInfo: UserInfo(value: 42)))
+        XCTAssertEqual(userInfo?.value, 42)
+    }
+    
+    func testMultipleWithUserInfo() {
+        struct UserInfo {
+            let value: Int
+        }
+        let router = Router<UserInfo>(scheme: scheme, url: url)
+        var userInfo: UserInfo?
+        router.register([
+            ("static", { context in
+                let isExpectedURL = context.url == URL(string: "foobar://static")! || context.url == URL(string: "https://example.com/static")!
+                XCTAssertTrue(isExpectedURL)
+                userInfo = context.userInfo
+                return true
+            }),
+        ])
+        XCTAssertTrue(router.openIfPossible(URL(string: "foobar://static")!, userInfo: UserInfo(value: 42)))
         XCTAssertTrue(router.openIfPossible(URL(string: "https://example.com/static")!, userInfo: UserInfo(value: 42)))
         XCTAssertFalse(router.openIfPossible(URL(string: "static")!, userInfo: UserInfo(value: 42)))
         XCTAssertEqual(userInfo?.value, 42)


### PR DESCRIPTION
# Goal
Allows Router to handle multiple prefixes (Universal Links and Custom URL Scheme) in one object

# Issue
Related?: https://github.com/giginet/Crossroad/issues/31

# Focused Problems

If developers want to use CrossRoad for universal URL and custom scheme url in them app, developers should prepare 2 router object, like, 

```swift
let routerForCustomScheme = SimpleRouter(scheme: "pokedex")
let routerForUniversalScheme = SimpleRouter(url:  URL(string: "https://my-awesome-pokedex.com")!)

// 1. Registering patterns for both schemes
routerForCustomScheme.register ...
routerForUniversalScheme.register ...

// 2. Handling from provided URL by Crossroad user by checking prefix of URL string
if urlString.hasPrefix("https://my-awesome-pokedex.com") {
    routerForUniversalScheme.openIfPossible ...
} else if urlString.hasPrefix("pokedex://") {
    routerForCustomScheme.openIfPossible ...
}
```

I think that there are 2 issues which Crossroad users feel redundant.

1. Registering patterns for both schemes by two object. 
   - it produces duplicated code and sometimes makes it hard to maintain code. We cannot detect like: if one is obeying business logic correctly but another one is not. 
2. Handling from provided URL by Crossroad user by checking prefix of URL string
   - If users prepared 2 routers, they still have to handle comparing prefixes of passed URL by themselves.
 
# Solution (My Change)
So I prepared a new initializer that allows using both schemes in one router object.

```swift
let router = SimpleRouter(scheme: "pokedex", url:  URL(string: "https://my-awesome-pokedex.com")!)

// 1. Registering patterns only once! (patterns must not have prefix)
router.register([
     (":pokemonName", { _ in ... }),
        ...
])

// 2. Handling both scheme in one object without checking prefix by ourselves!
router.openIfPossible(URL(string: "https://my-awesome-pokedex.com/pikachu")!) // Universal
router.openIfPossible(URL(string: "pokedex://pikachu")!) // Custom Scheme
```

# Test
I already added a test that fulfills the rule of exiting tests but please tell me if other are missing