### PR TITLE
Fix universal link parser

### DIFF
--- a/Sources/Crossroad/ContextParser.swift
+++ b/Sources/Crossroad/ContextParser.swift
@@ -8,6 +8,7 @@ public class ContextParser<UserInfo> {
 
     public enum Error: Swift.Error {
         case schemeIsMismatch
+        case hostIsMismatch
         case componentIsMismatch(expected: String, actual: String)
         case componentsCountMismatch
         case invalidURL
@@ -41,6 +42,7 @@ public class ContextParser<UserInfo> {
 
         case .universalLink(let universalLinkURL):
             guard url.scheme?.lowercased() == universalLinkURL.scheme?.lowercased() else { throw Error.schemeIsMismatch }
+            guard url.host?.lowercased() == universalLinkURL.host?.lowercased() else { throw Error.hostIsMismatch }
 
             expectedComponents = pattern.path.components
             actualURLComponents = url.pathComponents.droppedSlashElement() // only pathComponents

--- a/Tests/CrossroadTests/ParserTests.swift
+++ b/Tests/CrossroadTests/ParserTests.swift
@@ -20,6 +20,7 @@ final class ParserTests: XCTestCase {
             ("pokedex://pokemons/fire", "POKEDEX://POKEMONS/FIRE", false, #line),
             ("pokedex://", "pokedex://", true, #line),
             ("http://my-awesome-pokedex.com", "http://my-awesome-pokedex.com", true, #line),
+            ("http://my-awesome-pokedex.com/pokemons/:id", "http://totally-different-url.com/pokemons/100", false, #line),
         ]
 
         for (patternString, urlString, result, line) in testCases {

--- a/Tests/CrossroadTests/Router_AcceptanceTests.swift
+++ b/Tests/CrossroadTests/Router_AcceptanceTests.swift
@@ -42,15 +42,21 @@ final class Router_AcceptanceTests: XCTestCase {
             registry.group(accepting: [anotherUniversalLink]) { group in
                 group.route("/moves/:id") { _ in }
             }
+
+            registry.route("/") { _ in }
         }
 
         XCTAssertFalse(router.responds(to: URL(string: "pokedex://pokemons/:id")!))
         XCTAssertFalse(router.responds(to: URL(string: "pokedex://moves/:id")!))
+        XCTAssertTrue(router.responds(to: URL(string: "pokedex://")!))
 
         XCTAssertTrue(router.responds(to: URL(string: "https://my-awesome-pokedex.com/pokemons/:id")!))
         XCTAssertFalse(router.responds(to: URL(string: "https://my-awesome-pokedex.com/moves/:id")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://my-awesome-pokedex.com/")!))
+
         XCTAssertFalse(router.responds(to: URL(string: "https://another-pokedex.com/pokemons/:id")!))
         XCTAssertTrue(router.responds(to: URL(string: "https://another-pokedex.com/moves/:id")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://another-pokedex.com/")!))
     }
 
     func testGroupDSLWithWrongFactory() throws {

--- a/Tests/CrossroadTests/Router_AcceptanceTests.swift
+++ b/Tests/CrossroadTests/Router_AcceptanceTests.swift
@@ -5,6 +5,7 @@ import Crossroad
 final class Router_AcceptanceTests: XCTestCase {
     private let customURLScheme: LinkSource = .customURLScheme("pokedex")
     private let universalLink: LinkSource = .universalLink(URL(string: "https://my-awesome-pokedex.com")!)
+    private let anotherUniversalLink: LinkSource = .universalLink(URL(string: "https://another-pokedex.com")!)
 
     func testAcceptOnly() throws {
         let router = try SimpleRouter(accepting: [customURLScheme, universalLink]) { registry in
@@ -30,6 +31,26 @@ final class Router_AcceptanceTests: XCTestCase {
         XCTAssertTrue(router.responds(to: URL(string: "https://my-awesome-pokedex.com/pokemons/:id")!))
         XCTAssertTrue(router.responds(to: URL(string: "pokedex://moves/:id")!))
         XCTAssertFalse(router.responds(to: URL(string: "https://my-awesome-pokedex.com/moves/:id")!))
+    }
+
+    func testAcceptOnlyWithGroupWithAnotherUniversalLink() throws {
+        let router = try SimpleRouter(accepting: [customURLScheme, universalLink, anotherUniversalLink]) { registry in
+            registry.group(accepting: [universalLink]) { group in
+                group.route("/pokemons/:id") { _ in }
+            }
+
+            registry.group(accepting: [anotherUniversalLink]) { group in
+                group.route("/moves/:id") { _ in }
+            }
+        }
+
+        XCTAssertFalse(router.responds(to: URL(string: "pokedex://pokemons/:id")!))
+        XCTAssertFalse(router.responds(to: URL(string: "pokedex://moves/:id")!))
+
+        XCTAssertTrue(router.responds(to: URL(string: "https://my-awesome-pokedex.com/pokemons/:id")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://my-awesome-pokedex.com/moves/:id")!))
+        XCTAssertFalse(router.responds(to: URL(string: "https://another-pokedex.com/pokemons/:id")!))
+        XCTAssertTrue(router.responds(to: URL(string: "https://another-pokedex.com/moves/:id")!))
     }
 
     func testGroupDSLWithWrongFactory() throws {

--- a/Tests/CrossroadTests/Router_AcceptanceTests.swift
+++ b/Tests/CrossroadTests/Router_AcceptanceTests.swift
@@ -57,6 +57,9 @@ final class Router_AcceptanceTests: XCTestCase {
         XCTAssertFalse(router.responds(to: URL(string: "https://another-pokedex.com/pokemons/:id")!))
         XCTAssertTrue(router.responds(to: URL(string: "https://another-pokedex.com/moves/:id")!))
         XCTAssertTrue(router.responds(to: URL(string: "https://another-pokedex.com/")!))
+
+        XCTAssertFalse(router.responds(to: URL(string: "https://invalid-pokedex.com/")!))
+        XCTAssertFalse(router.responds(to: URL(string: "invalid_scheme://")!))
     }
 
     func testGroupDSLWithWrongFactory() throws {


### PR DESCRIPTION
ContextParser can't compare between universaLink sources correctly.
The parser doesn't care URL hosts at all. 

Due to this miss-implementation, a router that has multiple univerallink sources may not work correctly.

I fixed this issue and add tests.