### PR TITLE
Remove UserInfo from unnecessary methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If you maintain a complex application and you want to use independent URL patter
 You can use `ContextParser`.
 
 ```swift
-let parser = ContextParser<Void>()
+let parser = ContextParser()
 let context = parser.parse(URL(string: "pokedex:/pokemons/25")!, 
                            with: "pokedex://pokemons/:id")
 ```

--- a/Sources/Crossroad/Context.swift
+++ b/Sources/Crossroad/Context.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Arguments {
+public struct Arguments {
     enum Error: Swift.Error {
         case keyNotFound(String)
         case couldNotParse(Parsable.Type)
@@ -72,9 +72,33 @@ public struct QueryParameters {
     private var storage: [URLQueryItem]
 }
 
-public struct Context<UserInfo> {
+public protocol ContextProtocol {
+    var url: URL { get }
+    var arguments: Arguments { get }
+    var queryParameters: QueryParameters { get }
+}
+
+extension ContextProtocol {
+    func attach<UserInfo>(_ userInfo: UserInfo) -> Context<UserInfo> {
+        Context<UserInfo>(url: url, arguments: arguments, queryParameters: queryParameters, userInfo: userInfo)
+    }
+}
+
+struct AbstractContext: ContextProtocol {
+    let url: URL
+    let arguments: Arguments
+    let queryParameters: QueryParameters
+
+    init(url: URL, arguments: Arguments, queryParameters: QueryParameters) {
+        self.url = url
+        self.arguments = arguments
+        self.queryParameters = queryParameters
+    }
+}
+
+public struct Context<UserInfo>: ContextProtocol {
     public let url: URL
-    private let arguments: Arguments
+    public let arguments: Arguments
     public let queryParameters: QueryParameters
     public let userInfo: UserInfo
 
@@ -84,7 +108,9 @@ public struct Context<UserInfo> {
         self.queryParameters = queryParameters
         self.userInfo = userInfo
     }
+}
 
+extension ContextProtocol {
     @available(*, deprecated, message: "subscript for an argument is depricated.", renamed: "argument(named:)")
     public subscript<T: Parsable>(argument keyword: String) -> T? {
         return try? arguments.get(named: keyword)

--- a/Sources/Crossroad/Context.swift
+++ b/Sources/Crossroad/Context.swift
@@ -81,7 +81,7 @@ public protocol ContextProtocol {
 
 extension ContextProtocol {
     func attach<UserInfo>(_ userInfo: UserInfo) -> Context<UserInfo> {
-        Context<UserInfo>(url: url, arguments: internalArgumentsContainer, queryParameters: queryParameters, userInfo: userInfo)
+        Context<UserInfo>(url: url, internalArgumentsContainer: internalArgumentsContainer, queryParameters: queryParameters, userInfo: userInfo)
     }
 }
 
@@ -103,9 +103,9 @@ public struct Context<UserInfo>: ContextProtocol {
     public let queryParameters: QueryParameters
     public let userInfo: UserInfo
 
-    internal init(url: URL, arguments: Arguments, queryParameters: QueryParameters, userInfo: UserInfo) {
+    internal init(url: URL, internalArgumentsContainer: Arguments, queryParameters: QueryParameters, userInfo: UserInfo) {
         self.url = url
-        self.internalArgumentsContainer = arguments
+        self.internalArgumentsContainer = internalArgumentsContainer
         self.queryParameters = queryParameters
         self.userInfo = userInfo
     }
@@ -159,6 +159,6 @@ extension ContextProtocol {
 
 extension Context where UserInfo == Void {
     init(url: URL, arguments: Arguments, queryParameters: QueryParameters) {
-        self.init(url: url, arguments: arguments, queryParameters: queryParameters, userInfo: ())
+        self.init(url: url, internalArgumentsContainer: arguments, queryParameters: queryParameters, userInfo: ())
     }
 }

--- a/Sources/Crossroad/Context.swift
+++ b/Sources/Crossroad/Context.swift
@@ -74,37 +74,38 @@ public struct QueryParameters {
 
 public protocol ContextProtocol {
     var url: URL { get }
-    var arguments: Arguments { get }
+    /// This struct is for internal usage.
+    var internalArgumentsContainer: Arguments { get }
     var queryParameters: QueryParameters { get }
 }
 
 extension ContextProtocol {
     func attach<UserInfo>(_ userInfo: UserInfo) -> Context<UserInfo> {
-        Context<UserInfo>(url: url, arguments: arguments, queryParameters: queryParameters, userInfo: userInfo)
+        Context<UserInfo>(url: url, arguments: internalArgumentsContainer, queryParameters: queryParameters, userInfo: userInfo)
     }
 }
 
 struct AbstractContext: ContextProtocol {
     let url: URL
-    let arguments: Arguments
+    let internalArgumentsContainer: Arguments
     let queryParameters: QueryParameters
 
     init(url: URL, arguments: Arguments, queryParameters: QueryParameters) {
         self.url = url
-        self.arguments = arguments
+        self.internalArgumentsContainer = arguments
         self.queryParameters = queryParameters
     }
 }
 
 public struct Context<UserInfo>: ContextProtocol {
     public let url: URL
-    public let arguments: Arguments
+    public let internalArgumentsContainer: Arguments
     public let queryParameters: QueryParameters
     public let userInfo: UserInfo
 
     internal init(url: URL, arguments: Arguments, queryParameters: QueryParameters, userInfo: UserInfo) {
         self.url = url
-        self.arguments = arguments
+        self.internalArgumentsContainer = arguments
         self.queryParameters = queryParameters
         self.userInfo = userInfo
     }
@@ -113,7 +114,7 @@ public struct Context<UserInfo>: ContextProtocol {
 extension ContextProtocol {
     @available(*, deprecated, message: "subscript for an argument is depricated.", renamed: "argument(named:)")
     public subscript<T: Parsable>(argument keyword: String) -> T? {
-        return try? arguments.get(named: keyword)
+        return try? internalArgumentsContainer.get(named: keyword)
     }
 
     @available(*, deprecated, message: "Use queryParameters[key] instead")
@@ -122,7 +123,7 @@ extension ContextProtocol {
     }
 
     public func argument<T: Parsable>(named key: String, as type: T.Type = T.self) throws -> T {
-        return try arguments.get(named: key)
+        return try internalArgumentsContainer.get(named: key)
     }
 
     @available(*, deprecated, renamed: "queryParameter(named:)")

--- a/Sources/Crossroad/ContextParser.swift
+++ b/Sources/Crossroad/ContextParser.swift
@@ -3,7 +3,7 @@ import Foundation
 @available(*, deprecated, renamed: "ContextParser")
 public typealias URLParser = ContextParser
 
-public class ContextParser<UserInfo> {
+public class ContextParser {
     private let keywordPrefix = ":"
 
     public enum Error: Swift.Error {
@@ -16,17 +16,17 @@ public class ContextParser<UserInfo> {
 
     public init() { }
 
-    public func parse(_ url: URL, with patternString: String, userInfo: UserInfo) throws -> Context<UserInfo> {
+    public func parse(_ url: URL, with patternString: String) throws -> ContextProtocol {
         let pattern = try Pattern(patternString: patternString)
-        return try parse(url, with: pattern, userInfo: userInfo)
+        return try parse(url, with: pattern)
     }
 
     @available(*, deprecated, renamed: "parse(_:with:userInfo:)")
-    public func parse(_ url: URL, in patternString: String, userInfo: UserInfo) throws -> Context<UserInfo> {
-        try parse(url, with: patternString, userInfo: userInfo)
+    public func parse(_ url: URL, in patternString: String) throws -> ContextProtocol {
+        try parse(url, with: patternString)
     }
 
-    func parse(_ url: URL, with pattern: Pattern, userInfo: UserInfo) throws -> Context<UserInfo> {
+    func parse(_ url: URL, with pattern: Pattern) throws -> ContextProtocol {
         let expectedComponents: [String]
         let actualURLComponents: [String]
         let shouldBeCaseSensitives: [Bool]
@@ -69,7 +69,7 @@ public class ContextParser<UserInfo> {
 
         let argumentContainer = Arguments(arguments)
         let parameters = parseParameters(from: url)
-        return Context<UserInfo>(url: url, arguments: argumentContainer, queryParameters: parameters, userInfo: userInfo)
+        return AbstractContext(url: url, arguments: argumentContainer, queryParameters: parameters)
     }
 
     private func compare(_ lhs: String, _ rhs: String, isCaseSensitive: Bool) -> Bool {
@@ -88,16 +88,5 @@ public class ContextParser<UserInfo> {
             parameters = []
         }
         return QueryParameters(parameters)
-    }
-}
-
-extension ContextParser where UserInfo == Void {
-    public func parse(_ url: URL, with patternString: String) throws -> Context<UserInfo> {
-        return try parse(url, with: patternString, userInfo: ())
-    }
-
-    @available(*, deprecated, renamed: "parse(_:with:)")
-    public func parse(_ url: URL, in patternString: String) throws -> Context<UserInfo> {
-        try parse(url, with: patternString, userInfo: ())
     }
 }

--- a/Sources/Crossroad/OpenURLOption.swift
+++ b/Sources/Crossroad/OpenURLOption.swift
@@ -32,10 +32,6 @@ public extension Router where UserInfo == OpenURLOption {
     func openIfPossible(_ url: URL, options: ApplicationOpenURLOptions) -> Bool {
         return openIfPossible(url, userInfo: OpenURLOption(options: options))
     }
-
-    func responds(to url: URL, options: ApplicationOpenURLOptions) -> Bool {
-        return responds(to: url, userInfo: OpenURLOption(options: options))
-    }
 }
 
 @available(iOS 13.0, *)
@@ -43,10 +39,6 @@ extension Router where UserInfo == OpenURLOption {
     @discardableResult
     public func openIfPossible(_ url: URL, options: UIScene.OpenURLOptions) -> Bool {
         return openIfPossible(url, userInfo: OpenURLOption(options: options))
-    }
-
-    public func responds(to url: URL, options: UIScene.OpenURLOptions) -> Bool {
-        return responds(to: url, userInfo: OpenURLOption(options: options))
     }
 }
 

--- a/Tests/CrossroadTests/ContextTests.swift
+++ b/Tests/CrossroadTests/ContextTests.swift
@@ -13,7 +13,7 @@ final class ContextTests: XCTestCase {
 
     var context: Context<Void> {
         return  Context<Void>(url: url,
-                              arguments: Arguments(["pokedexID": "25", "name": "Pikachu"]),
+                              internalArgumentsContainer: Arguments(["pokedexID": "25", "name": "Pikachu"]),
                               queryParameters: QueryParameters([
                                 URLQueryItem(name: "name", value: "Pikachu"),
                                 URLQueryItem(name: "type", value: "electric"),

--- a/Tests/CrossroadTests/OpenURLOptionTests.swift
+++ b/Tests/CrossroadTests/OpenURLOptionTests.swift
@@ -19,7 +19,7 @@ final class OpenURLOptionTests: XCTestCase {
 
     func testContextWithOpenURLOption() {
         let context = Context<OpenURLOption>(url: URL(string: "https://example.com")!,
-                                             arguments: .init([:]),
+                                             internalArgumentsContainer: .init([:]),
                                              queryParameters: .init([]),
                                              userInfo: options)
         XCTAssertEqual(context.options.sourceApplication, "org.giginet.myapp")

--- a/Tests/CrossroadTests/ParserTests.swift
+++ b/Tests/CrossroadTests/ParserTests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 final class ParserTests: XCTestCase {
     func testURLParser() throws {
-        let parser = ContextParser<Void>()
+        let parser = ContextParser()
         let patternString = "pokedex://pokemons/:pokedexID"
         let context = try parser.parse(URL(string: "pokedex://pokemons/25")!, with: patternString)
         XCTAssertEqual(try context.argument(named: "pokedexID"), 25)
     }
 
     func testPatternCase() throws {
-        let parser = ContextParser<Void>()
+        let parser = ContextParser()
 
         let testCases: [(String, String, Bool, UInt)] = [
             ("http://my-awesome-pokedex.com/pokemons", "HTTP://MY-AWESOME-POKEDEX.COM/pokemons", true, #line),


### PR DESCRIPTION
`ContextParser` and `Router.responds(to:)` don't need `UserInfo`.

Thanks to introduce `ContextProtocol`. They don't require unnecessary payloads.